### PR TITLE
sort start and target IS

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -96,6 +96,7 @@ void parse_stfile(const char *filename, std::vector<int> *start_set,
             {
                 vec->push_back(bv);
             }
+            std::sort(vec->begin(), vec->end());
         }
     }
 }


### PR DESCRIPTION
In the C++ version (and only there) the start and target IS are not sorted before comparing to an answers first step. Returning with Code10 if the sets are not sorted (for example queen008x008_01_4136).
